### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
       "android"
     ]
   },
+  "engines": {
+    "cordovaDependencies": {
+      "2.0.0": {
+        "cordova": ">100"
+      }
+    }
+  },
   "keywords": [
     "Cordova",
     "Microsoft",


### PR DESCRIPTION
This adds `engines` element to comply w/ [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).

Its also desirable to add 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.